### PR TITLE
Fix DEFAULT_CONFIG path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+## [0.0.3] - 2015-09-09
+### Fixed
+- bad relative default JSON config addressing;

--- a/lib/spore/config.rb
+++ b/lib/spore/config.rb
@@ -8,7 +8,8 @@ module Spore
 
     DEPLOYMENT_VAR = "SPORE_DEPLOYMENT"
     CONFIG_FILE = "config.json"
-    DEFAULT_CONFIG = "./lib/config/default.json"
+    DEFAULT_CONFIG = File.expand_path(
+      "../config/default.json", File.dirname(__FILE__))
 
     class << self
       def is_deployment?

--- a/lib/spore/version.rb
+++ b/lib/spore/version.rb
@@ -2,7 +2,7 @@ module Spore
   class Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 2
+    PATCH = 3
 
     class << self
       def to_s


### PR DESCRIPTION
This was broken because when the gem was used in a Rails project the '.' in the path referred to Rails.root instead of the gem root.
